### PR TITLE
feat(montage): add bash+python concatenators with smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ skeleton_videos/_tmp/
 !docs/assets/*.mp4
 !data/videos_norm/*.mp4
 !data/videos_skeleton_norm/*.mp4
+_tmp/
+list*.txt
+*.mkv
+
+#editor junk
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test montage montage_py
+
+test:
+	./tests/test_smoke.sh
+
+montage:
+	./scripts/montage.sh -l _tmp/list.txt -o _out/concat.mp4
+
+montage_py:
+	./scripts/montage.py -l _tmp/list.txt -o _out/concat.mp4

--- a/render_skeleton_video.py
+++ b/render_skeleton_video.py
@@ -139,6 +139,7 @@ def render_from_npz(npz_path, out_path, mode='normalized', fps=30, trail=25, bg=
 
 def main():
     ap = argparse.ArgumentParser()
+
     ap.add_argument("--npz", help="path to one *_series.npz")
     ap.add_argument("--glob", help="glob for multiple npz files (e.g., 'outputs/*_series.npz')")
     ap.add_argument("--out", help="output mp4 path (single)")

--- a/scripts/montage.py
+++ b/scripts/montage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import argparse, subprocess, shlex, sys, tempfile, os
+
+def run(cmd):
+    print(">>", cmd)
+    return subprocess.run(shlex.split(cmd))
+
+def normalize_inputs(list_file, wh_fps, label=None, crf=18, preset="veryfast"):
+    W, H, FPS = wh_fps
+    list_dir = os.path.dirname(os.path.abspath(list_file))
+    tmpdir = tempfile.mkdtemp(prefix="montage_norm_")
+    nlist = os.path.join(tmpdir, "nlist.txt")
+    with open(list_file) as f, open(nlist, "w") as out:
+        for i, line in enumerate(l for l in f if l.strip()):
+            path = line.strip().replace("file ", "").strip("'")
+            if not os.path.isabs(path):                           
+                path = os.path.join(list_dir, path)   
+            if not os.path.isfile(path):
+                sys.exit(f"Missing: {path}")
+            outp = os.path.join(tmpdir, f"n_{i}.mp4")
+            if label:
+                vf = (
+                    f"[0:v]fps={FPS},scale={W}:{H}:flags=bicubic,setsar=1,format=yuv420p,"
+                    f"drawtext=fontfile='/System/Library/Fonts/Supplemental/Arial.ttf':"
+                    f"text='{label}':fontcolor=white:fontsize=22:x=12:y=h-28:"
+                    f"box=1:boxcolor=black@0.55:boxborderw=6[v]"
+                )
+                cmd = f"ffmpeg -y -i '{path}' -filter_complex \"{vf}\" -map \"[v]\" -an -c:v libx264 -crf {crf} -preset {preset} '{outp}'"
+            else:
+                cmd = f"ffmpeg -y -i '{path}' -vf \"fps={FPS},scale={W}:{H}:flags=bicubic,setsar=1,format=yuv420p\" -an -c:v libx264 -crf {crf} -preset {preset} '{outp}'"
+            rc = run(cmd).returncode
+            if rc != 0:
+                sys.exit("Normalization failed.")
+            out.write(f"file '{outp}'\n")
+    return nlist
+
+def parse_whfps(s):
+    try:
+        wh, fps = s.split("@")
+        w, h = wh.split("x")
+        return int(w), int(h), int(fps)
+    except Exception:
+        raise argparse.ArgumentTypeError("Use WxH@FPS, e.g. 480x270@30")
+
+def main():
+    ap = argparse.ArgumentParser(description="Concatenate videos from list file.")
+    ap.add_argument("-l","--list", required=True, help="ffmpeg concat demuxer list file")
+    ap.add_argument("-o","--out", default="_out/concat.mp4")
+    ap.add_argument("--force-encode", action="store_true")
+    ap.add_argument("--normalize", type=parse_whfps, help="e.g., 480x270@30")
+    ap.add_argument("--crf", type=int, default=18)
+    ap.add_argument("--preset", default="veryfast")
+    ap.add_argument("--xfade", type=float, help="crossfade seconds between clips")
+    ap.add_argument("--label", help="draw same label on each clip")
+    args = ap.parse_args()
+
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+
+    list_file = args.list
+    # Optional normalization
+    if args.normalize:
+        list_file = normalize_inputs(list_file, args.normalize, label=args.label, crf=18, preset="veryfast")
+
+    # If xfade requested, build a filter graph concat with re-encode.
+    if args.xfade:
+        # Build command: inputs are the normalized ones
+        with open(list_file) as f:
+            paths = [ln.strip().replace("file ","").strip("'") for ln in f if ln.strip()]
+        # Prepare -i args
+        in_args = " ".join([f"-i '{p}'" for p in paths])
+        # Build filter chain
+        fps = args.normalize[2] if args.normalize else 30
+        chains = [f"[{i}:v]fps={fps},format=yuv420p[v{i}];" for i in range(len(paths))]
+        if len(paths) == 1:
+            mapout = "[v0]"
+            fc = "".join(chains)
+        else:
+            fc = "".join(chains)
+            # pairwise xfade chain
+            dur = args.xfade
+            offset = max(0.0, (1.0 * (args.normalize[2] if args.normalize else 30)) - dur)  # just a placeholder offset
+            fc += f"[v0][v1]xfade=transition=fade:duration={dur}:offset={offset}[x1];"
+            last = "x1"
+            for i in range(2, len(paths)):
+                # cascade, keep same duration per segment; simple layout
+                fc += f"[{last}][v{i}]xfade=transition=fade:duration={dur}:offset={(offset)*i}[x{i}];"
+                last = f"x{i}"
+            mapout = f"[{last}]"
+
+        cmd = (
+            f"ffmpeg -y {in_args} -filter_complex \"{fc}\" "
+            f"-map \"{mapout}\" -c:v libx264 -crf {args.crf} -preset {args.preset} -pix_fmt yuv420p -movflags +faststart "
+            f"\"{args.out}\""
+        )
+        rc = run(cmd).returncode
+        sys.exit(rc)
+
+    # Otherwise: try stream copy then fallback
+    if not args.force_encode and not args.normalize and not args.label:
+        rc = run(f"ffmpeg -y -f concat -safe 0 -i '{list_file}' -c copy '{args.out}'").returncode
+        if rc == 0:
+            sys.exit(0)
+        print("Stream copy failed; falling back to re-encode...")
+
+    rc = run(
+        f"ffmpeg -y -f concat -safe 0 -i '{list_file}' "
+        f"-vsync cfr -pix_fmt yuv420p -c:v libx264 -crf {args.crf} -preset {args.preset} -movflags +faststart "
+        f"'{args.out}'"
+    ).returncode
+    sys.exit(rc)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/montage.sh
+++ b/scripts/montage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Linear concatenation from a list file.
+# Usage:
+#   ./scripts/montage.sh -l _tmp/list.txt -o _out/concat.mp4
+# Options:
+#   -l, --list FILE      concat list file (ffmpeg concat demuxer format)
+#   -o, --out  FILE      output mp4 path
+#   --force-encode       skip -c copy and re-encode
+#   --normalize  WxH@FPS normalize each clip before concat (e.g., 480x270@30)
+#   --crf N              CRF for encode (default 18)
+#   --preset P           x264 preset (default veryfast)
+#   --label "TEXT"       overlay the same label on every clip (tiny, bottom-left)
+
+LIST=""
+OUT="_out/concat.mp4"
+FORCE_ENCODE=0
+NORM=""
+CRF=18
+PRESET="veryfast"
+LABEL=""
+
+FONT_DEFAULT="/System/Library/Fonts/Supplemental/Arial.ttf"
+FONT_PATH="${FONT_PATH:-$FONT_DEFAULT}"
+
+usage(){ grep -E '^#' "$0" | sed -E 's/^# ?//'; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -l|--list) LIST="$2"; shift 2;;
+    -o|--out) OUT="$2"; shift 2;;
+    --force-encode) FORCE_ENCODE=1; shift;;
+    --normalize) NORM="$2"; shift 2;;
+    --crf) CRF="$2"; shift 2;;
+    --preset) PRESET="$2"; shift 2;;
+    --label) LABEL="$2"; shift 2;;
+    -h|--help) usage;;
+    *) echo "Unknown arg: $1"; usage;;
+  esac
+done
+
+[[ -f "$LIST" ]] || { echo "List file not found: $LIST" >&2; exit 1; }
+mkdir -p "$(dirname "$OUT")"
+
+# Optionally normalize each file to ensure identical params.
+if [[ -n "$NORM" ]]; then
+  # Parse WxH@FPS
+  if [[ "$NORM" =~ ^([0-9]+)x([0-9]+)@([0-9]+)$ ]]; then
+    W="${BASH_REMATCH[1]}"; H="${BASH_REMATCH[2]}"; FPS="${BASH_REMATCH[3]}"
+  else
+    echo "Bad --normalize value. Use WxH@FPS (e.g., 480x270@30)"; exit 1
+  fi
+  tmpdir="$(mktemp -d)"
+  nlist="$tmpdir/nlist.txt"
+  i=0
+  while read -r line; do
+    [[ -z "$line" ]] && continue
+    f=${line#file }
+    f=${f//\'/}
+    [[ -f "$f" ]] || { echo "Missing: $f" >&2; exit 1; }
+    out="$tmpdir/n_$i.mp4"
+    if [[ -n "$LABEL" ]]; then
+      ffmpeg -y -i "$f" -filter_complex \
+        "[0:v]fps=${FPS},scale=${W}:${H}:flags=bicubic,setsar=1,format=yuv420p,\
+         drawtext=fontfile='${FONT_PATH}':text='${LABEL}':fontcolor=white:fontsize=22:\
+         x=12:y=h-28:box=1:boxcolor=black@0.55:boxborderw=6[v]" \
+        -map "[v]" -an -c:v libx264 -crf 18 -preset veryfast "$out"
+    else
+      ffmpeg -y -i "$f" -vf "fps=${FPS},scale=${W}:${H}:flags=bicubic,setsar=1,format=yuv420p" \
+        -an -c:v libx264 -crf 18 -preset veryfast "$out"
+    fi
+    echo "file '$out'" >> "$nlist"
+    i=$((i+1))
+  done < "$LIST"
+  LIST="$nlist"
+fi
+
+# Try lossless concat first unless forced to encode.
+if [[ $FORCE_ENCODE -eq 0 && -z "$LABEL" && -z "$NORM" ]]; then
+  if ffmpeg -y -f concat -safe 0 -i "$LIST" -c copy "$OUT"; then
+    echo "Wrote $OUT (stream copy)"; exit 0
+  else
+    echo "Stream copy failed; falling back to re-encode..."
+  fi
+fi
+
+# Re-encode concat (robust).
+ffmpeg -y -f concat -safe 0 -i "$LIST" \
+  -vsync cfr -pix_fmt yuv420p \
+  -c:v libx264 -crf "$CRF" -preset "$PRESET" -movflags +faststart \
+  "$OUT"
+
+echo "Wrote $OUT"

--- a/tests/test_smoke.sh
+++ b/tests/test_smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p _tmp _out
+
+# make 3 tiny test clips (480x270@30) inside _tmp
+ffmpeg -y -f lavfi -t 1 -i color=c=red:s=480x270:r=30 _tmp/a.mp4  >/dev/null 2>&1
+ffmpeg -y -f lavfi -t 1 -i color=c=green:s=480x270:r=30 _tmp/b.mp4 >/dev/null 2>&1
+ffmpeg -y -f lavfi -t 1 -i color=c=blue:s=480x270:r=30 _tmp/c.mp4  >/dev/null 2>&1
+
+# IMPORTANT: entries are relative to the list file location (_tmp/)
+cat > _tmp/list.txt <<EOF
+file 'a.mp4'
+file 'b.mp4'
+file 'c.mp4'
+EOF
+
+# bash version (copy or encode fallback)
+./scripts/montage.sh -l _tmp/list.txt -o _out/smoke_copy.mp4
+
+# python version with normalize + re-encode
+./scripts/montage.py -l _tmp/list.txt --normalize 480x270@30 -o _out/smoke_encode.mp4
+
+[[ -s _out/smoke_copy.mp4 ]] && echo "bash smoke OK"
+[[ -s _out/smoke_encode.mp4 ]] && echo "python smoke OK"


### PR DESCRIPTION
Added montage.sh and montage.py for concatenation.

Added tests/test_smoke.sh and Makefile for automated smoke testing.

Tools support auto-fallback, normalization, and labels.

CI ready to hook into make test.